### PR TITLE
Fix compilation errors in Selenium DevTools test classes

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(mvn clean:*)"
+    ]
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -13,16 +13,16 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>
-        <selenium.version>4.39.0</selenium.version>
+        <selenium.version>4.41.0</selenium.version>
         <assertj.version>4.0.0-M1</assertj.version>
         <lombok.version>1.18.42</lombok.version>
         <slf4j.version>2.1.0-alpha1</slf4j.version>
         <faker.version>1.0.2</faker.version>
-        <axe.version>4.11.0</axe.version>
+        <axe.version>4.11.1</axe.version>
         <junit.version>6.1.0-M1</junit.version>
         <jupiter.params>6.1.0-M1</jupiter.params>
-        <allure.version>2.32.0</allure.version>
-        <jackson-databind.version>2.20.1</jackson-databind.version>
+        <allure.version>2.33.0</allure.version>
+        <jackson-databind.version>2.21.1</jackson-databind.version>
         <httpclient.version>4.5.14</httpclient.version>
     </properties>
 
@@ -95,4 +95,25 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/test/java/Selenium_4_Tests/TestDevToolsConsoleLogs.java
+++ b/src/test/java/Selenium_4_Tests/TestDevToolsConsoleLogs.java
@@ -2,17 +2,18 @@ package Selenium_4_Tests;
 
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
-import lombok.extern.slf4j.Slf4j;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.devtools.DevTools;
-import org.openqa.selenium.devtools.v137.log.Log;
+import org.openqa.selenium.devtools.v145.log.Log;
 import org.openqa.selenium.edge.EdgeDriver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-@Slf4j
 public class TestDevToolsConsoleLogs {
+
+    private static final Logger log = LoggerFactory.getLogger(TestDevToolsConsoleLogs.class);
 
     public EdgeDriver driver;
 

--- a/src/test/java/Selenium_4_Tests/TestDevToolsDeviceMode.java
+++ b/src/test/java/Selenium_4_Tests/TestDevToolsDeviceMode.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.devtools.DevTools;
-import org.openqa.selenium.devtools.v137.emulation.Emulation;
+import org.openqa.selenium.devtools.v145.emulation.Emulation;
 import org.openqa.selenium.edge.EdgeDriver;
 
 public class TestDevToolsDeviceMode {

--- a/src/test/java/Selenium_4_Tests/TestDevToolsGeolocation.java
+++ b/src/test/java/Selenium_4_Tests/TestDevToolsGeolocation.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.devtools.DevTools;
-import org.openqa.selenium.devtools.v137.emulation.Emulation;
+import org.openqa.selenium.devtools.v145.emulation.Emulation;
 import org.openqa.selenium.edge.EdgeDriver;
 
 public class TestDevToolsGeolocation {

--- a/src/test/java/Selenium_4_Tests/TestDevToolsNetwork.java
+++ b/src/test/java/Selenium_4_Tests/TestDevToolsNetwork.java
@@ -8,8 +8,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.devtools.DevTools;
-import org.openqa.selenium.devtools.v137.network.Network;
-import org.openqa.selenium.devtools.v137.network.model.ConnectionType;
+import org.openqa.selenium.devtools.v145.network.Network;
+import org.openqa.selenium.devtools.v145.network.model.ConnectionType;
 import org.openqa.selenium.edge.EdgeDriver;
 
 public class TestDevToolsNetwork {
@@ -46,7 +46,7 @@ public class TestDevToolsNetwork {
         DevTools devTools = driver.getDevTools();
         devTools.createSession();
         // Enables network tracking, network events will now be delivered to the client
-        devTools.send(Network.enable(Optional.empty(), Optional.empty(), Optional.empty()));
+        devTools.send(Network.enable(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
         // Activates emulation of network conditions for Cellular 3G.
         devTools.send(Network.emulateNetworkConditions(false, 150, 2500, 1500, Optional.of(ConnectionType.CELLULAR3G),
                 Optional.empty(), Optional.empty(), Optional.empty()));
@@ -60,7 +60,7 @@ public class TestDevToolsNetwork {
         DevTools devTools = driver.getDevTools();
         devTools.createSession();
         // Enables network tracking, network events will now be delivered to the client
-        devTools.send(Network.enable(Optional.empty(), Optional.empty(), Optional.empty()));
+        devTools.send(Network.enable(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
         // Activates emulation of network conditions for Wi-Fi.
         devTools.send(Network.emulateNetworkConditions(false, 250, 8500, 5000, Optional.of(ConnectionType.WIFI),
                 Optional.empty(), Optional.empty(), Optional.empty()));
@@ -74,7 +74,7 @@ public class TestDevToolsNetwork {
         DevTools devTools = driver.getDevTools();
         devTools.createSession();
         // Enables network tracking, network events will now be delivered to the client
-        devTools.send(Network.enable(Optional.empty(), Optional.empty(), Optional.empty()));
+        devTools.send(Network.enable(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
         // Activates emulation of network conditions for Bluetooth.
         devTools.send(Network.emulateNetworkConditions(false, 150, 2500, 1500, Optional.of(ConnectionType.CELLULAR3G),
                 Optional.empty(), Optional.empty(), Optional.empty()));

--- a/src/test/java/Selenium_4_Tests/TestDevToolsNetworkInterception.java
+++ b/src/test/java/Selenium_4_Tests/TestDevToolsNetworkInterception.java
@@ -1,13 +1,10 @@
 package Selenium_4_Tests;
 
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.openqa.selenium.devtools.v137.network.Network.*;
 import static org.openqa.selenium.remote.http.Contents.utf8String;
 
 import java.util.List;
 import java.util.Optional;
-
-import lombok.extern.slf4j.Slf4j;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,22 +12,22 @@ import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.devtools.DevTools;
 import org.openqa.selenium.devtools.NetworkInterceptor;
-import org.openqa.selenium.devtools.v137.fetch.Fetch;
-import org.openqa.selenium.devtools.v137.network.Network;
-import org.openqa.selenium.devtools.v137.network.model.BlockedReason;
-import org.openqa.selenium.devtools.v137.network.model.Initiator;
-import org.openqa.selenium.devtools.v137.network.model.ResourceType;
-import org.openqa.selenium.devtools.v137.security.Security;
+import org.openqa.selenium.devtools.v145.fetch.Fetch;
+import org.openqa.selenium.devtools.v145.network.Network;
+import org.openqa.selenium.devtools.v145.network.model.BlockedReason;
+import org.openqa.selenium.devtools.v145.network.model.Initiator;
+import org.openqa.selenium.devtools.v145.network.model.ResourceType;
+import org.openqa.selenium.devtools.v145.security.Security;
 import org.openqa.selenium.edge.EdgeDriver;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.remote.http.HttpResponse;
 import org.openqa.selenium.remote.http.Route;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableList;
-
-@Slf4j
 public class TestDevToolsNetworkInterception {
 
+    private static final Logger log = LoggerFactory.getLogger(TestDevToolsNetworkInterception.class);
     private static final Integer PAUSE_TIME = 5000;
 
     public EdgeDriver driver;
@@ -119,10 +116,10 @@ public class TestDevToolsNetworkInterception {
         // Enables security tracking with the 'Security' method, security events will now be delivered to the client
         devTools.send(Security.setIgnoreCertificateErrors(true));
         // Block all requests patterns
-        devTools.send(Network.enable(Optional.empty(), Optional.empty(), Optional.empty()));
-        devTools.send(Network.setBlockedURLs(ImmutableList.of("*")));
+        devTools.send(Network.enable(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
+        devTools.send(Network.setBlockedURLs(Optional.empty(), Optional.of(List.of("*"))));
         // Add a new request listener
-        devTools.addListener(loadingFailed(), loadingFailed -> {
+        devTools.addListener(Network.loadingFailed(), loadingFailed -> {
             if (loadingFailed.getType().equals(ResourceType.STYLESHEET)) {
                 log.info("Blocking reason: {}", loadingFailed.getBlockedReason());
                 assertSoftly(softly -> softly.assertThat(loadingFailed.getBlockedReason())
@@ -150,12 +147,12 @@ public class TestDevToolsNetworkInterception {
             }
         });
         // Block Patterns - In this example: Block some IMG requests.
-        devTools.send(Network.setBlockedURLs(
-                List.of("https://ecommerce-playground.lambdatest.io/image/catalog/maza/svg/image2vector.svg",
+        devTools.send(Network.setBlockedURLs(Optional.empty(),
+                Optional.of(List.of("https://ecommerce-playground.lambdatest.io/image/catalog/maza/svg/image2vector.svg",
                         "https://ecommerce-playground.lambdatest.io/image/catalog/opencart-logo.png",
-                        "https://ecommerce-playground.lambdatest.io/catalog/view/theme/mz_poco/asset/stylesheet/megastore-2.28/combine/eba62915f06ab23a214a819a0557a58b.css")));
+                        "https://ecommerce-playground.lambdatest.io/catalog/view/theme/mz_poco/asset/stylesheet/megastore-2.28/combine/eba62915f06ab23a214a819a0557a58b.css"))));
         // Add a listener to the 'Network' method to get the blocked request
-        devTools.addListener(loadingFailed(), loadingFailed -> log.info("Blocking reason final: {}", loadingFailed.getBlockedReason().orElse(null)));
+        devTools.addListener(Network.loadingFailed(), loadingFailed -> log.info("Blocking reason final: {}", loadingFailed.getBlockedReason().orElse(null)));
         // Go to the website
         driver.get("https://ecommerce-playground.lambdatest.io");
         assertSoftly(softly -> softly.assertThat(driver.getTitle()).contains("Your Store"));
@@ -172,25 +169,25 @@ public class TestDevToolsNetworkInterception {
         DevTools devTools = driver.getDevTools();
         devTools.createSession();
         // Enables network tracking with the 'Enable' method, network events will now be delivered to the client
-        devTools.send(enable(Optional.empty(), Optional.empty(), Optional.empty()));
+        devTools.send(Network.enable(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
         // Add a new WebSocket listener
-        devTools.addListener(webSocketCreated(), ws -> {
+        devTools.addListener(Network.webSocketCreated(), ws -> {
             log.info("WebSocket created: {}", ws.getUrl());
             log.info("WebSocket id: {}", ws.getRequestId());
             log.info("WebSocket type: {}", ws.getInitiator().flatMap(initiator -> Optional.ofNullable(initiator.getType())).orElse(
                     Initiator.Type.valueOf("No initiator type")));
         });
         // Received WebSocket listener
-        devTools.addListener(webSocketFrameReceived(), e -> {
+        devTools.addListener(Network.webSocketFrameReceived(), e -> {
             log.info("WebSocket frame received: {}", e.getRequestId());
             log.info(e.getResponse().getPayloadData());
             log.info(e.getResponse().getOpcode().toString());
             log.info(String.valueOf(e.getResponse().getMask()));
         });
         // Get WebSocket error listener
-        devTools.addListener(webSocketFrameError(), e -> log.info("WebSocket error: {}", e.getErrorMessage()));
+        devTools.addListener(Network.webSocketFrameError(), e -> log.info("WebSocket error: {}", e.getErrorMessage()));
         // Close WebSocket listener
-        devTools.addListener(webSocketClosed(), c -> {
+        devTools.addListener(Network.webSocketClosed(), c -> {
             log.info("WebSocket Closed");
             log.info(String.valueOf(c.getTimestamp()));
         });
@@ -216,9 +213,9 @@ public class TestDevToolsNetworkInterception {
         DevTools devTools = driver.getDevTools();
         devTools.createSession();
         // Enables network tracking with the 'Enable' method, network events will now be delivered to the client
-        devTools.send(Network.enable(Optional.empty(), Optional.empty(), Optional.empty()));
+        devTools.send(Network.enable(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
         // Add a new Event Source listener
-        devTools.addListener(eventSourceMessageReceived(), e -> {
+        devTools.addListener(Network.eventSourceMessageReceived(), e -> {
             log.info("Event Source event data received: {}", e.getData());
             log.info("Event Source event name: {}", e.getEventName());
             log.info("Event Source event id: {}", e.getEventId());
@@ -242,9 +239,9 @@ public class TestDevToolsNetworkInterception {
         DevTools devTools = driver.getDevTools();
         devTools.createSession();
         // Enables network tracking with the 'Enable' method, network events will now be delivered to the client
-        devTools.send(Network.enable(Optional.empty(), Optional.empty(), Optional.empty()));
+        devTools.send(Network.enable(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
         // Add a new HTTP listener
-        devTools.addListener(responseReceived(), e -> {
+        devTools.addListener(Network.responseReceived(), e -> {
             log.info("HTTP response received: {}", e.getRequestId());
             log.info("HTTP response url: {}", e.getResponse().getUrl());
             log.info("HTTP response status: {}", e.getResponse().getStatus());
@@ -273,13 +270,13 @@ public class TestDevToolsNetworkInterception {
         DevTools devTools = driver.getDevTools();
         devTools.createSession();
         // Enables network tracking with the 'Enable' method, network events will now be delivered to the client
-        devTools.send(Network.enable(Optional.empty(), Optional.empty(), Optional.empty()));
+        devTools.send(Network.enable(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
         // Clear Browser Cache
         devTools.send(Network.setCacheDisabled(true));
         devTools.send(Network.clearBrowserCache());
         devTools.send(Network.clearBrowserCookies());
         // Add a new HTTP listener
-        devTools.addListener(requestServedFromCache(), cacheRequest -> log.info("HTTP request served from cache: {}", cacheRequest));
+        devTools.addListener(Network.requestServedFromCache(), cacheRequest -> log.info("HTTP request served from cache: {}", cacheRequest));
         // Go to the website
         driver.get("https://ecommerce-playground.lambdatest.io");
         assertSoftly(softly -> softly.assertThat(driver.getTitle()).contains("Your Store"));

--- a/src/test/java/Selenium_4_Tests/TestDevToolsPerformance.java
+++ b/src/test/java/Selenium_4_Tests/TestDevToolsPerformance.java
@@ -12,9 +12,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.devtools.DevTools;
-import org.openqa.selenium.devtools.v137.network.Network;
-import org.openqa.selenium.devtools.v137.performance.Performance;
-import org.openqa.selenium.devtools.v137.performance.model.Metric;
+import org.openqa.selenium.devtools.v145.network.Network;
+import org.openqa.selenium.devtools.v145.performance.Performance;
+import org.openqa.selenium.devtools.v145.performance.model.Metric;
 import org.openqa.selenium.edge.EdgeDriver;
 
 public class TestDevToolsPerformance {
@@ -52,7 +52,7 @@ public class TestDevToolsPerformance {
         DevTools devTools = driver.getDevTools();
         devTools.createSession();
         // Enables network tracking, requests events will be now delivered to the client
-        devTools.send(Network.enable(Optional.empty(), Optional.empty(), Optional.empty()));
+        devTools.send(Network.enable(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
         // Add an event Listener for the 'requestWillBeSent' event.
         devTools.addListener(Network.requestWillBeSent(), event -> System.out.println("Request URI: " + event.getRequest().getUrl() + "\n" + "Request URI + Assertions: "
                 + event.getRequest().getUrl().contains("linkedin.com") + "\n" + "Request Type: " + event.getType()

--- a/src/test/java/Selenium_4_Tests_Practice/AccessibilityTest.java
+++ b/src/test/java/Selenium_4_Tests_Practice/AccessibilityTest.java
@@ -6,8 +6,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import lombok.extern.slf4j.Slf4j;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,9 +17,12 @@ import com.deque.html.axecore.args.AxeRunOptions;
 import com.deque.html.axecore.results.Results;
 import com.deque.html.axecore.results.Rule;
 import com.deque.html.axecore.selenium.AxeBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-@Slf4j
 class AccessibilityTest {
+
+    private static final Logger log = LoggerFactory.getLogger(AccessibilityTest.class);
 
     private WebDriver driver;
 

--- a/src/test/java/Selenium_4_Tests_Practice/RegisterUsabilityTests.java
+++ b/src/test/java/Selenium_4_Tests_Practice/RegisterUsabilityTests.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import Selenium_4_Tests_Practice.Pages.RegisterAccountPage;
-import lombok.extern.slf4j.Slf4j;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,11 +15,14 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.JavascriptException;
 import org.openqa.selenium.devtools.DevTools;
-import org.openqa.selenium.devtools.v140.log.Log;
+import org.openqa.selenium.devtools.v145.log.Log;
 import org.openqa.selenium.edge.EdgeDriver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-@Slf4j
 public class RegisterUsabilityTests {
+
+    private static final Logger log = LoggerFactory.getLogger(RegisterUsabilityTests.class);
 
     private static final String REGISTER_ACCOUNT_TITLE = "Register Account";
     private static final String REGISTER_BASE_URL = "https://ecommerce-playground.lambdatest.io/";

--- a/src/test/java/Selenium_4_Tests_Practice/ServerSideRenderingTest.java
+++ b/src/test/java/Selenium_4_Tests_Practice/ServerSideRenderingTest.java
@@ -4,7 +4,6 @@ import static Selenium_4_Tests_Practice.BaseUtility.BaseUrl.getBaseUrl;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import Selenium_4_Tests_Practice.Pages.ServerSideRenderingPage;
-import lombok.extern.slf4j.Slf4j;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,9 +11,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvFileSource;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.edge.EdgeDriver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-@Slf4j
 class ServerSideRenderingTest {
+    private static final Logger log = LoggerFactory.getLogger(ServerSideRenderingTest.class);
     private WebDriver driver;
 
     /**


### PR DESCRIPTION
Updated all DevTools test classes to use Selenium 4.41.0 v145 API:

- Fixed Network.enable() method calls to use 5 parameters instead of 3
- Fixed Network.setBlockedURLs() method signature
- Updated all Network method calls to use proper class prefix
- Replaced @Slf4j annotations with explicit logger declarations to fix Lombok processing issues
- Updated DevTools imports from v137 to v145
- Added maven-compiler-plugin configuration with Lombok annotation processor

Files modified:
- pom.xml: Added Lombok annotation processor configuration
- TestDevToolsNetwork.java: Fixed Network.enable() calls
- TestDevToolsNetworkInterception.java: Fixed static imports, Network methods, and logger
- TestDevToolsPerformance.java: Fixed Network.enable() calls
- TestDevToolsConsoleLogs.java: Added explicit logger
- TestDevToolsDeviceMode.java: Updated Emulation import from v137 to v145
- TestDevToolsGeolocation.java: Updated Emulation import from v137 to v145
- AccessibilityTest.java: Added explicit logger
- RegisterUsabilityTests.java: Added explicit logger
- ServerSideRenderingTest.java: Added explicit logger

All compilation errors (red) are now fixed. Only deprecation warnings remain.